### PR TITLE
Zadanie5

### DIFF
--- a/5home/main.cpp
+++ b/5home/main.cpp
@@ -1,0 +1,101 @@
+#include <thread>
+#include <iostream>
+#include <ctime>
+#include <memory>
+#include <condition_variable>
+#include <mutex>
+ 
+using std::cout;
+using std::endl;
+ 
+const double M=8e8;
+ 
+//Shared_Work holds the work need to be done
+//part1() and part2() separates the work half-and-half
+//n1 and n2 are data items
+//chunk[64] is the separation attempt.
+//we can also separate date with alignas() 
+class Shared_Work {
+public:
+    Shared_Work():n1(1),n2(1),flag1(0),flag2(0) {}
+ 
+    void part1() {
+        for(; n1<M; n1+=n1%3);
+        flag1=1;
+        cond.notify_one();
+    }
+ 
+    void part2() {
+        for(; n2<M; n2+=n2%3);
+        flag2=1;
+        cond.notify_one();
+    }
+ 
+    long int result() {
+        std::unique_lock<std::mutex> lk(mt);
+        while(flag1==0||flag2==0)
+            cond.wait(lk);
+        return n1+n2;
+    }
+ 
+private:
+    std::mutex mt;
+    std::condition_variable cond;
+    alignas(64) long int n1;
+    // char chuck[64];//cache line seperation
+    alignas(64) long int n2;
+    bool flag1;
+    bool flag2;
+};
+ 
+//a template class for generating threads with different member functions
+//"action _fptr" will be instantiated by &Shared_Work::part1 and part2.
+template<class T>
+class Do_Work {
+public:
+    typedef void (T::*action)();
+    Do_Work(std::shared_ptr<Shared_Work>& x, action y):_p(x),_fptr(y) {}
+    void operator()() {
+        (*_p.*_fptr)();
+    }
+private:
+    std::shared_ptr<Shared_Work> _p;
+    action _fptr;
+};
+ 
+//single thread work to do
+void one_thread() {
+    long int n1=1, n2=1;
+    for(; n1<M; n1+=n1%3);
+    for(; n2<M; n2+=n2%3);
+    cout<<n1+n2<<endl;
+}
+ 
+ 
+ 
+time_t start, end;
+double diff;
+ 
+int main(int argc, char* argv[]) {
+ 
+    std::shared_ptr<Shared_Work> p(new Shared_Work);
+    Do_Work<Shared_Work> d1(p, &Shared_Work::part1);
+    Do_Work<Shared_Work> d2(p, &Shared_Work::part2);
+ 
+    time(&start);
+    std::thread t1( d1 );
+    std::thread t2( d2 );
+    t1.detach();//release the ownership to C++ runtime library.
+    t2.detach();//release the ownership to C++ runtime library.
+    cout<<p->result()<<endl;
+    time(&end);
+    diff=difftime(end, start);
+    cout<<diff<<" seconds elapsed for 2 threads calculation."<<endl;
+ 
+    time(&start);
+    one_thread();
+    time(&end);
+    diff=difftime(end, start);
+    cout<<diff<<" seconds elapsed for 1 thread calculation."<<endl;
+ 
+}

--- a/zadanie2.cpp
+++ b/zadanie2.cpp
@@ -1,0 +1,93 @@
+#include <thread>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <functional>
+#include <numeric>
+#include <iterator>
+#include <chrono>
+#include <assert.h>
+
+
+constexpr short int minSize = 5000;
+
+template <typename IT, typename T>
+T t_accumulate (IT first, IT last, T init)
+{
+    const size_t distance = std::distance(first, last);
+    const size_t maxThreads = std::thread::hardware_concurrency() != 0 ? std::thread::hardware_concurrency() : 2;
+    if(distance > 0 and distance < minSize)
+        return std::accumulate (first, last, init);
+    else if (!distance)
+        return init;
+    
+    const size_t neededThreads = std::min(distance/minSize, maxThreads);
+    const size_t dataChunk = distance / neededThreads;
+
+    std::vector<std::thread> vThreads (neededThreads-1);
+    std::vector<T> results (neededThreads);
+
+    auto begin = first;
+
+    for(size_t i = 0; i < neededThreads - 1; i++)
+    {
+        auto end = std::next(begin, dataChunk);
+        vThreads[i] = std::thread([](IT first, IT last, T& result)
+            {
+                result = std::accumulate(first, last, T{});
+            }, begin, end, std::ref(results[i]));
+        begin = end;
+    }
+
+    results[neededThreads-1] = std::accumulate(begin, last, T{});
+    std::for_each(vThreads.begin(), vThreads.end(), std::mem_fn(&std::thread::join));
+
+    return std::accumulate(std::begin(results), std::end(results), init);
+}
+
+void printTime (const decltype(std::chrono::high_resolution_clock::now()) &startStandard,
+                const decltype(startStandard) &stopStandard,
+                const decltype(startStandard) &startPararel,
+                const decltype(startPararel) &stopPararel,
+                const size_t &elements)
+{
+     std::cout << "\nPararel algorithm for [" << elements << "]: " 
+		<< std::chrono::duration_cast<std::chrono::microseconds>(stopPararel - startPararel).count() 
+		<< "us" << std::endl;
+	std::cout << "\nNormal algorithm for [" << elements << "]: "
+		<< std::chrono::duration_cast<std::chrono::microseconds>(stopStandard - startStandard).count() 
+		<< "us" << std::endl;
+}
+
+void useAlgorithm(const std::vector<int> &v)
+{
+    auto start = std::chrono::high_resolution_clock::now();
+    size_t standardCount = std::accumulate(v.begin(), v.end(), 0);
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    auto start3 = std::chrono::high_resolution_clock::now();
+    size_t pararelCount = t_accumulate(std::begin(v), std::end(v), 0);
+    auto stop3 = std::chrono::high_resolution_clock::now();
+
+    assert(standardCount==pararelCount);
+
+    printTime(start, stop, start3, stop3, v.size());
+}
+
+int main()
+{
+    std::vector <int> v (400'000'000);
+    std::generate(v.begin(), v.end(),  [n=0] () mutable {return n++;});
+    useAlgorithm(v);
+
+    v.resize(100'000'000);
+    useAlgorithm(v);
+
+    v.resize(5'000);
+    useAlgorithm(v);
+
+    v.resize(2'500);
+    useAlgorithm(v);
+    
+    return 0;
+}

--- a/zadanie3.cpp
+++ b/zadanie3.cpp
@@ -14,10 +14,10 @@ template <typename IT, typename UP>
 int t_count_if(IT first, IT last, UP predicate)
 {
     const size_t distance = std::distance(first, last);
-    if(distance < minDataSize)
+    const size_t maxThreads = std::thread::hardware_concurrency();
+    if(distance < minDataSize or maxThreads == 0)
         return std::count_if(first, last, predicate);
 
-    const size_t maxThreads = std::thread::hardware_concurrency();
     const size_t neededThreads = std::min(distance/minDataSize, maxThreads);
     const size_t dataChunk = distance / neededThreads;
     std::vector<size_t> results (neededThreads);
@@ -40,7 +40,7 @@ int t_count_if(IT first, IT last, UP predicate)
     return std::accumulate(std::begin(results), std::end(results), 0);
 }
 
-void printTime (const decltype(std::chrono::steady_clock::now()) &startStandard,
+void printTime (const decltype(std::chrono::high_resolution_clock::now()) &startStandard,
                 const decltype(startStandard) &stopStandard,
                 const decltype(startStandard) &startPararel,
                 const decltype(startPararel) &stopPararel,
@@ -56,13 +56,13 @@ void printTime (const decltype(std::chrono::steady_clock::now()) &startStandard,
 
 void useAlgorithm(const std::vector<int> &v)
 {
-    auto start = std::chrono::steady_clock::now();
+    auto start = std::chrono::high_resolution_clock::now();
     size_t standardCount = std::count_if(v.begin(), v.end(), [](const int &a){return a%2 == 0;});
-    auto stop = std::chrono::steady_clock::now();
+    auto stop = std::chrono::high_resolution_clock::now();
 
-    auto start3 = std::chrono::steady_clock::now();
+    auto start3 = std::chrono::high_resolution_clock::now();
     size_t pararelCount = t_count_if(std::begin(v), std::end(v), [](const int &a){return a%2 == 0;});
-    auto stop3 = std::chrono::steady_clock::now();
+    auto stop3 = std::chrono::high_resolution_clock::now();
 
     assert(standardCount==pararelCount);
 

--- a/zadanie3.cpp
+++ b/zadanie3.cpp
@@ -1,0 +1,88 @@
+#include <thread>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <functional>
+#include <numeric>
+#include <iterator>
+#include <chrono>
+#include <assert.h>
+
+constexpr size_t minDataSize = 5000;
+
+template <typename IT, typename UP>
+int t_count_if(IT first, IT last, UP predicate)
+{
+    const size_t distance = std::distance(first, last);
+    if(distance < minDataSize)
+        return std::count_if(first, last, predicate);
+
+    const size_t maxThreads = std::thread::hardware_concurrency();
+    const size_t neededThreads = std::min(distance/minDataSize, maxThreads);
+    const size_t dataChunk = distance / neededThreads;
+    std::vector<size_t> results (neededThreads);
+    std::vector<std::thread> vThreads (neededThreads-1);
+
+    auto begin = first;
+    
+    for(size_t i = 0; i < neededThreads-1; ++i)
+    {
+        auto end = std::next(begin, dataChunk);
+        vThreads[i] = std::thread([](IT first, IT last, UP predicate, size_t &result)
+        {   
+            result = std::count_if(first, last, predicate);
+        }, begin, end, predicate, std::ref(results[i]));
+        begin = end;
+    };
+
+    results[neededThreads-1]=std::count_if(begin, last, predicate);
+    std::for_each(vThreads.begin(), vThreads.end(), std::mem_fn(&std::thread::join));
+    return std::accumulate(std::begin(results), std::end(results), 0);
+}
+
+void printTime (const decltype(std::chrono::steady_clock::now()) &startStandard,
+                const decltype(startStandard) &stopStandard,
+                const decltype(startStandard) &startPararel,
+                const decltype(startPararel) &stopPararel,
+                const size_t &elements)
+{
+     std::cout << "\nPararel algorithm for [" << elements << "]: " 
+		<< std::chrono::duration_cast<std::chrono::microseconds>(stopPararel - startPararel).count() 
+		<< "us" << std::endl;
+	std::cout << "\nNormal algorithm for [" << elements << "]: "
+		<< std::chrono::duration_cast<std::chrono::microseconds>(stopStandard - startStandard).count() 
+		<< "us" << std::endl;
+}
+
+void useAlgorithm(const std::vector<int> &v)
+{
+    auto start = std::chrono::steady_clock::now();
+    size_t standardCount = std::count_if(v.begin(), v.end(), [](const int &a){return a%2 == 0;});
+    auto stop = std::chrono::steady_clock::now();
+
+    auto start3 = std::chrono::steady_clock::now();
+    size_t pararelCount = t_count_if(std::begin(v), std::end(v), [](const int &a){return a%2 == 0;});
+    auto stop3 = std::chrono::steady_clock::now();
+
+    assert(standardCount==pararelCount);
+
+    printTime(start, stop, start3, stop3, v.size());
+}
+
+int main()
+{
+    std::vector <int> v (400'000'000);
+    std::generate(v.begin(), v.end(),  [n=0] () mutable {return n++;});
+    useAlgorithm(v);
+
+    v.resize(100'000'000);
+    useAlgorithm(v);
+
+    v.resize(5'000);
+    useAlgorithm(v);
+
+    v.resize(2'500);
+    useAlgorithm(v);
+    
+    return 0;
+}


### PR DESCRIPTION
False sharing występuje w momencie kiedy przynajmniej dwa wątki operują na tej samej linii cache'u.
W momencie kiedy pracują one na różnych danych znajdujących się w tej samej linii pamięci performance programu pogorszy się (może się okazać, że będzie lepiej dane zadanie zrobić na jednym wątku). Aby zapobiec bezsensownym wymianom i aktualizacjom linii cache'u (które zajmują dużo czasu) można rozwiązać to za pomocą **padding'u** bądź specyfikatora **alignas()**.
Z racji tego, że wielkość linii pamięci może być różna (popularne 32,64 oraz 128 bajtów) 
można użyć:
std::hardware_destructive_interference_size  -
zwróci minimalny offset pomiędzy dwoma obiektami który jest wymagany, aby uniknąć fałszywego współdzielenia, jednak w programie nie został użyty z powodu braku wsparcia ze strony g++.

Czas wykonywania programu bez interweniowania w alokację obiektów:
2 wątki - 5s
1 wątek - 5s

Czas wykonywania programu z alignas() / data chunkiem (char chunk[64])
2 wątki - 2s
1 wątek  - 5s

Aby uniknąć false sharingu powinno się ograniczać alokowanie zmiennych globalnych ponieważ jedna po drugiej mają bardzo duże szansę na zostanie zaalokowanymi w jednej linii cache'u (obok siebie)  i stworzy to warunki do ewentualnego fałszywego współdzielenia.
Należy w miarę możliwości takie obiekty alokować bezpośrednio w funkcji którą wykonuje dany wątek, przez co obiekt zostanie zaalokowany na stosie wątku.
Jeżeli nie ma takiej możliwości (bądź nie taki jest zamysł konstrukcji programu) należy użyć już wcześniej wspomnianego **paddingu** , specyfikatora **alignas(wielokrotność 2)** lub alignas(std::hardware_destructive_interference_size) aby mieć pewność, że dane będą rozmieszczone w różnych liniach pamięci.

$getconf LEVEL1_DCACHE_LINESIZE
komedna za pomocą której w systemie linux, przez terminal można się dowiedzieć jaką wielkość ma nasza linia pamięci